### PR TITLE
스레드 입력 페이지 기능 추가 및 스크롤 가능 하도록 변경 

### DIFF
--- a/ThreadApp.xcodeproj/project.pbxproj
+++ b/ThreadApp.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-
-		F1F333122A8DF5B60055240C /* PlistProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F333112A8DF5B60055240C /* PlistProvider.swift */; };
-		F1F333142A8DF8040055240C /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F333132A8DF8040055240C /* MainViewController.swift */; };
+		F1F29DA62A8FD1F000DDD1A3 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F29DA52A8FD1F000DDD1A3 /* UIStackView+.swift */; };
 		F1F333052A8DA6020055240C /* CornerRadiusChangableUIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F333042A8DA6020055240C /* CornerRadiusChangableUIImageView.swift */; };
 		F1F333082A8DA7A30055240C /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F333072A8DA7A30055240C /* UIView+.swift */; };
+		F1F333122A8DF5B60055240C /* PlistProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F333112A8DF5B60055240C /* PlistProvider.swift */; };
+		F1F333142A8DF8040055240C /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F333132A8DF8040055240C /* MainViewController.swift */; };
 		FFD8F5862A89C6F500A1EFC4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD8F5852A89C6F500A1EFC4 /* AppDelegate.swift */; };
 		FFD8F5882A89C6F500A1EFC4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD8F5872A89C6F500A1EFC4 /* SceneDelegate.swift */; };
 		FFD8F58A2A89C6F500A1EFC4 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD8F5892A89C6F500A1EFC4 /* ViewController.swift */; };
@@ -40,10 +40,11 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		F1F333112A8DF5B60055240C /* PlistProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlistProvider.swift; sourceTree = "<group>"; };
-		F1F333132A8DF8040055240C /* MainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+		F1F29DA52A8FD1F000DDD1A3 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		F1F333042A8DA6020055240C /* CornerRadiusChangableUIImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CornerRadiusChangableUIImageView.swift; sourceTree = "<group>"; };
 		F1F333072A8DA7A30055240C /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
+		F1F333112A8DF5B60055240C /* PlistProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlistProvider.swift; sourceTree = "<group>"; };
+		F1F333132A8DF8040055240C /* MainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		FFD8F5822A89C6F500A1EFC4 /* ThreadApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ThreadApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FFD8F5852A89C6F500A1EFC4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FFD8F5872A89C6F500A1EFC4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -88,6 +89,7 @@
 			isa = PBXGroup;
 			children = (
 				F1F333072A8DA7A30055240C /* UIView+.swift */,
+				F1F29DA52A8FD1F000DDD1A3 /* UIStackView+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -261,10 +263,10 @@
 				FFE4F2612A8C6D2600BCC86D /* ProfilePageModal.swift in Sources */,
 				FFE4F2582A8C5F1200BCC86D /* MainCollectionViewController.swift in Sources */,
 				F1F333052A8DA6020055240C /* CornerRadiusChangableUIImageView.swift in Sources */,
-				FFE4F2562A8C5EEA00BCC86D /* MainViewController.swift in Sources */,
 				FFD8F58A2A89C6F500A1EFC4 /* ViewController.swift in Sources */,
 				FFD8F5A22A89C9C500A1EFC4 /* Comment.swift in Sources */,
 				FFE4F2452A8A207D00BCC86D /* ThreadDataSingleton.swift in Sources */,
+				F1F29DA62A8FD1F000DDD1A3 /* UIStackView+.swift in Sources */,
 				FFE4F23F2A8A0A2000BCC86D /* CreateViewController.swift in Sources */,
 				FFD8F5A02A89C99600A1EFC4 /* Profile.swift in Sources */,
 				F1F333082A8DA7A30055240C /* UIView+.swift in Sources */,

--- a/ThreadApp/Extension/UIStackView+.swift
+++ b/ThreadApp/Extension/UIStackView+.swift
@@ -1,0 +1,72 @@
+//
+//  UIStackView+.swift
+//  ThreadApp
+//
+//  Created by hong on 2023/08/19.
+//
+
+import UIKit
+
+extension UIStackView {
+    @IBInspectable
+    var layoutMarginTop: CGFloat {
+        get {
+            self.layoutMargins.top
+        }
+        set {
+            setLayoutMargin(
+                top: newValue,
+                bottom: self.layoutMargins.bottom,
+                left: self.layoutMargins.left,
+                right: self.layoutMargins.right
+            )
+        }
+    }
+    @IBInspectable
+    var layoutMarginBottom: CGFloat {
+        get {
+            self.layoutMargins.bottom
+        }
+        set {
+            setLayoutMargin(
+                top: self.layoutMargins.top,
+                bottom: newValue,
+                left: self.layoutMargins.left,
+                right: self.layoutMargins.right
+            )
+        }
+    }
+    @IBInspectable
+    var layoutMarginLeft: CGFloat {
+        get {
+            self.layoutMargins.left
+        }
+        set {
+            setLayoutMargin(
+                top: self.layoutMargins.top,
+                bottom: self.layoutMargins.bottom,
+                left: newValue,
+                right: self.layoutMargins.right
+            )
+        }
+    }
+    @IBInspectable
+    var layoutMarginRight: CGFloat {
+        get {
+            self.layoutMargins.right
+        }
+        set {
+            setLayoutMargin(
+                top: self.layoutMargins.top,
+                bottom: self.layoutMargins.bottom,
+                left: self.layoutMargins.left,
+                right: newValue
+            )
+        }
+    }
+    
+    func setLayoutMargin(top: CGFloat, bottom: CGFloat, left: CGFloat, right: CGFloat) {
+        self.layoutMargins = UIEdgeInsets(top: top, left: left, bottom: bottom, right: right)
+        self.isLayoutMarginsRelativeArrangement = true
+    }
+}

--- a/ThreadApp/Extension/UIView+.swift
+++ b/ThreadApp/Extension/UIView+.swift
@@ -17,5 +17,33 @@ extension UIView {
             self.layer.cornerRadius = newValue
         }
     }
+    
+    func addTopBorderWithColor(color: UIColor, width: CGFloat) {
+        let border = CALayer()
+        border.backgroundColor = color.cgColor
+        border.frame = CGRect(x: 0, y: 0, width: self.frame.size.width, height: width)
+        self.layer.addSublayer(border)
+    }
+
+    func addRightBorderWithColor(color: UIColor, width: CGFloat) {
+        let border = CALayer()
+        border.backgroundColor = color.cgColor
+        border.frame = CGRect(x: self.frame.size.width - width, y: 0, width: width, height: self.frame.size.height)
+        self.layer.addSublayer(border)
+    }
+
+    func addBottomBorderWithColor(color: UIColor, width: CGFloat) {
+        let border = CALayer()
+        border.backgroundColor = color.cgColor
+        border.frame = CGRect(x: 0, y: self.frame.size.height - width, width: self.frame.size.width, height: width)
+        self.layer.addSublayer(border)
+    }
+
+    func addLeftBorderWithColor(color: UIColor, width: CGFloat) {
+        let border = CALayer()
+        border.backgroundColor = color.cgColor
+        border.frame = CGRect(x: 0, y: 0, width: width, height: self.frame.size.height)
+        self.layer.addSublayer(border)
+    }
 }
 

--- a/ThreadApp/Model/ThreadDataSingleton.swift
+++ b/ThreadApp/Model/ThreadDataSingleton.swift
@@ -13,6 +13,7 @@ class ThreadStore {
     
     var threads: [Thread] = [] // Thread 객체들을 저장할 배열
     private let threadsKey = "savedThreads"
+    private let profileKey = "profile"
     
 }
 
@@ -26,6 +27,16 @@ extension ThreadStore {
             UserDefaults.standard.set(encodedThreads, forKey: threadsKey)
         } catch {
             print("Failed to encode threads: \(error)")
+        }
+    }
+    
+    func loadProfile() -> Profile?  {
+        do {
+            guard let savedProfileData = UserDefaults.standard.data(forKey: profileKey) else { return nil }
+            let profileData = try JSONDecoder().decode(Profile.self, from: savedProfileData)
+            return profileData
+        } catch {
+            return nil
         }
     }
     

--- a/ThreadApp/ViewController/CreateViewController.swift
+++ b/ThreadApp/ViewController/CreateViewController.swift
@@ -9,61 +9,77 @@ import UIKit
 
 
 
-class CreateViewController: UIViewController, UITextViewDelegate {
+final class CreateViewController: UIViewController {
     
-    
+    @IBOutlet weak var profileImageView: UIImageView!
     @IBOutlet weak var userName: UILabel!
     @IBOutlet weak var threadText: UITextView!
-    
-    @IBOutlet weak var threadTitle: UITextField!
+    @IBOutlet weak var scrollView: UIScrollView!
+    @IBOutlet weak var threadImageView: UIImageView!
+    private var selectedImageData: Data? = nil
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        let rightButton = UIBarButtonItem(title: "게시", style: .plain, target: self, action: #selector(yourFunction))
-        self.navigationItem.rightBarButtonItem = rightButton
-        
-        // UITextViewDelegate 설정
-        threadText.delegate = self
-        
-        // 키보드 관련 Notification 설정
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
-        
-        let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 50))
-        toolbar.items = [
-            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil), // 왼쪽에 공간을 만들어서 버튼을 오른쪽으로 밀어줍니다.
-            UIBarButtonItem(title: "게시", style: .done, target: self, action: #selector(createButton(_:)))
-        ]
-        threadText.inputAccessoryView = toolbar
-        // 사용자 이름 불러오기
-        let userNameText = loadUserName()
-        
-        // 사용자 이름을 라벨에 표시
-        userName.text = userNameText
+
+        configureThreadTextView()
+        configureKeyboardSetting()
+        configureProfileInformationViews()
+
     }
-    
+
     deinit {
         // Notification 제거
         NotificationCenter.default.removeObserver(self)
     }
     
-    @objc func yourFunction(){
-        print("안녕")
+    private func configureThreadTextView() {
+        threadText.isScrollEnabled = false
+        // UITextViewDelegate 설정
+        threadText.delegate = self
+        threadText.translatesAutoresizingMaskIntoConstraints = false
+        threadText.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        threadText.layer.borderWidth = 1
+        threadText.layer.borderColor = UIColor.black.cgColor
+        threadText.text = "여기에 내용을 입력하세요."
+        threadText.textColor = .lightGray
+        textViewDidChange(threadText)
     }
     
-    @IBAction func cancelButton(_ sender: UIBarButtonItem) {
+    private func configureKeyboardSetting() {
+        // 키보드 관련 Notification 설정
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    private func configureProfileInformationViews() {
+        if let profile = ThreadStore.shared.loadProfile() {
+            userName.text = profile.name
+            if let profileImageData = profile.photoData {
+                profileImageView.image = UIImage(data: profileImageData)
+            }
+        }
+        
+        threadImageView.isUserInteractionEnabled = true
+        let threadImageViewGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(imageViewTapped))
+        threadImageView.addGestureRecognizer(threadImageViewGestureRecognizer)
+    }
+
+    @IBAction private func cancelButtonTapped(_ sender: Any) {
         self.dismiss(animated: true, completion: nil)
     }
     
-    @IBAction func createButton(_ sender: UIBarButtonItem) {
+    @objc private func imageViewTapped(_ sender: UITapGestureRecognizer) {
+        let imagePicker = UIImagePickerController()
+        imagePicker.delegate = self
+        imagePicker.sourceType = .photoLibrary
+        self.present(imagePicker, animated: true, completion: nil)
+    }
+    
+    @IBAction private func postingButtonTapped(_ sender: Any) {
         // 사용자 이름 불러오기
         let userNameText = loadUserName()
         print(userNameText)
         
-        
-        
-        let title = threadTitle.text ?? ""
         let text = threadText.text ?? ""
         let currentDateTime = Date()
         
@@ -72,7 +88,7 @@ class CreateViewController: UIViewController, UITextViewDelegate {
         
         let authorPhotoData = ThreadStore.shared.loadProfile()?.photoData
         let author = Profile(photoData: authorPhotoData, name: authorName, bio: "UserBio")
-        let newThread = Thread(title: title, createdAt: currentDateTime, content: text, photoData: nil, authorProfile: author, comments: nil)
+        let newThread = Thread(title: "", createdAt: currentDateTime, content: text, photoData: selectedImageData, authorProfile: author, comments: nil)
         
         ThreadStore.shared.addThread(thread: newThread)
         
@@ -81,40 +97,10 @@ class CreateViewController: UIViewController, UITextViewDelegate {
         
         // 게시글 게시 후 모달 내리기
         self.dismiss(animated: true, completion: nil)
+        self.view.isUserInteractionEnabled = true
     }
     
-    // UITextViewDelegate 메소드
-    func textViewDidBeginEditing(_ textView: UITextView) {
-        if textView.text == "스레드를 시작하세요..." { // 플레이스 홀더 체크
-            textView.text = ""
-            textView.textColor = .black
-        }
-    }
-    
-    func textViewDidEndEditing(_ textView: UITextView) {
-        if textView.text == "" {
-            textView.text = "여기에 내용을 입력하세요."
-            textView.textColor = .lightGray
-        }
-    }
-    
-    @objc func keyboardWillShow(notification: NSNotification) {
-        // 필요한 경우 뷰를 올리는 로직 추가
-        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
-            if self.view.frame.origin.y == 0 {
-                self.view.frame.origin.y -= keyboardSize.height / 3  // 뷰를 키보드 높이의 1/3만큼 위로 이동
-            }
-        }
-    }
-    
-    @objc func keyboardWillHide(notification: NSNotification) {
-        // 필요한 경우 뷰를 원래 위치로 내리는 로직 추가
-        if self.view.frame.origin.y != 0 {
-            self.view.frame.origin.y = 0
-        }
-    }
-    
-    @objc func printStoredThreads() {
+    @objc private func printStoredThreads() {
         guard let savedThreadsData = UserDefaults.standard.data(forKey: "savedThreads") else {
             print("No threads saved in UserDefaults.")
             return
@@ -128,7 +114,8 @@ class CreateViewController: UIViewController, UITextViewDelegate {
             print("Failed to decode saved threads: \(error)")
         }
     }
-    func loadUserName() -> String {
+    
+    private func loadUserName() -> String {
         do {
             if let savedProfile = UserDefaults.standard.object(forKey: "profile") as? Data {
                 let profile = try JSONDecoder().decode(Profile.self, from: savedProfile)
@@ -139,8 +126,66 @@ class CreateViewController: UIViewController, UITextViewDelegate {
         }
         return "Unknown User"
     }
+
+    @objc private func keyboardWillShow(notification: NSNotification) {
+        // 필요한 경우 뷰를 올리는 로직 추가
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            scrollView.contentInset.bottom = keyboardSize.height
+        }
+    }
     
-    
+    @objc private func keyboardWillHide(notification: NSNotification) {
+        // 필요한 경우 뷰를 원래 위치로 내리는 로직 추가
+        scrollView.contentInset = .zero
+    }
     
 }
 
+extension CreateViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        if let image = info[.originalImage] as? UIImage {
+            selectedImageData = image.pngData()
+            DispatchQueue.main.async { [weak self] in
+                self?.threadImageView.image = image
+            }
+        }
+        picker.dismiss(animated: true, completion: nil)
+    }
+}
+
+extension CreateViewController: UITextViewDelegate {
+    // UITextViewDelegate 메소드
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.text == "스레드를 시작하세요..." ||
+            textView.text == "여기에 내용을 입력하세요." { // 플레이스 홀더 체크
+            textView.text = ""
+            textView.textColor = .black
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        view.endEditing(true)
+        if textView.text == "" {
+            textView.text = "여기에 내용을 입력하세요."
+            textView.textColor = .lightGray
+        }
+    }
+    
+    func textViewDidChange(_ textView: UITextView) {
+        let size = CGSize(width: view.frame.width-20, height: .infinity)
+        let estimatedSize = textView.sizeThatFits(size)
+        textView.constraints.forEach { (constraint) in
+            if constraint.firstAttribute == .height {
+                constraint.constant = estimatedSize.height
+            }
+        }
+    }
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if text == "\n" {
+            textView.resignFirstResponder()
+            return false
+        }
+        return true
+    }
+}

--- a/ThreadApp/ViewController/CreateViewController.swift
+++ b/ThreadApp/ViewController/CreateViewController.swift
@@ -16,11 +16,13 @@ final class CreateViewController: UIViewController {
     @IBOutlet weak var threadText: UITextView!
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var threadImageView: UIImageView!
+    @IBOutlet weak var topNavigationView: UIView!
     private var selectedImageData: Data? = nil
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        topNavigationView.addBottomBorderWithColor(color: .gray, width: 0.5)
         configureThreadTextView()
         configureKeyboardSetting()
         configureProfileInformationViews()

--- a/ThreadApp/ViewController/CreateViewController.swift
+++ b/ThreadApp/ViewController/CreateViewController.swift
@@ -70,7 +70,8 @@ class CreateViewController: UIViewController, UITextViewDelegate {
         // 사용자 이름을 불러옵니다.
         let authorName = loadUserName()
         
-        let author = Profile(photoData: nil, name: authorName, bio: "UserBio")
+        let authorPhotoData = ThreadStore.shared.loadProfile()?.photoData
+        let author = Profile(photoData: authorPhotoData, name: authorName, bio: "UserBio")
         let newThread = Thread(title: title, createdAt: currentDateTime, content: text, photoData: nil, authorProfile: author, comments: nil)
         
         ThreadStore.shared.addThread(thread: newThread)

--- a/ThreadApp/resource/Create.storyboard
+++ b/ThreadApp/resource/Create.storyboard
@@ -20,18 +20,24 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nud-gU-eRe">
                                 <rect key="frame" x="0.0" y="0.0" width="393" height="50"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FdX-W5-D59">
-                                        <rect key="frame" x="11" y="8" width="54" height="35"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FdX-W5-D59">
+                                        <rect key="frame" x="19.999999999999996" y="8" width="53.666666666666657" height="34.333333333333336"/>
+                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="취소"/>
                                         <connections>
                                             <action selector="cancelButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="1uS-c7-YWH"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgw-EF-dTt">
-                                        <rect key="frame" x="321" y="7" width="54" height="35"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="새로운 스레드" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xxu-hq-UKc">
+                                        <rect key="frame" x="137" y="11.999999999999998" width="119" height="26.333333333333329"/>
+                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgw-EF-dTt">
+                                        <rect key="frame" x="319.33333333333331" y="8" width="53.666666666666686" height="34.333333333333336"/>
+                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" title="게시"/>
                                         <connections>
@@ -39,9 +45,14 @@
                                         </connections>
                                     </button>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemGray2Color"/>
                                 <constraints>
+                                    <constraint firstItem="xxu-hq-UKc" firstAttribute="centerX" secondItem="nud-gU-eRe" secondAttribute="centerX" id="EKg-Pw-yCl"/>
+                                    <constraint firstItem="FdX-W5-D59" firstAttribute="centerY" secondItem="nud-gU-eRe" secondAttribute="centerY" id="Mkp-dm-neN"/>
+                                    <constraint firstItem="FdX-W5-D59" firstAttribute="leading" secondItem="nud-gU-eRe" secondAttribute="leading" constant="20" id="RQs-Ah-Gaf"/>
+                                    <constraint firstItem="xxu-hq-UKc" firstAttribute="centerY" secondItem="nud-gU-eRe" secondAttribute="centerY" id="TEQ-8X-4Yc"/>
                                     <constraint firstAttribute="height" constant="50" id="eph-YP-4jv"/>
+                                    <constraint firstItem="xgw-EF-dTt" firstAttribute="centerY" secondItem="nud-gU-eRe" secondAttribute="centerY" id="lR4-Xl-nSb"/>
+                                    <constraint firstAttribute="trailing" secondItem="xgw-EF-dTt" secondAttribute="trailing" constant="20" id="t3e-oy-Tvn"/>
                                 </constraints>
                             </view>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IaL-yq-pvP">
@@ -154,6 +165,7 @@
                         <outlet property="scrollView" destination="IaL-yq-pvP" id="PFj-ub-U2A"/>
                         <outlet property="threadImageView" destination="l2w-x3-Ql5" id="hVP-dz-g3E"/>
                         <outlet property="threadText" destination="XlT-qO-UvM" id="zkS-as-39O"/>
+                        <outlet property="topNavigationView" destination="nud-gU-eRe" id="1Te-bv-Q7I"/>
                         <outlet property="userName" destination="Uxn-Ai-1fT" id="oRB-zm-scM"/>
                     </connections>
                 </viewController>
@@ -176,9 +188,6 @@
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray2Color">
-            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/ThreadApp/resource/Create.storyboard
+++ b/ThreadApp/resource/Create.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,68 +17,144 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MDH-wb-mUF">
-                                <rect key="frame" x="0.0" y="59" width="393" height="44"/>
-                                <items>
-                                    <navigationItem title="Title" id="m34-Zn-Ku0">
-                                        <barButtonItem key="leftBarButtonItem" title="취소" id="lws-R1-PsJ">
-                                            <connections>
-                                                <action selector="cancelButton:" destination="Y6W-OH-hqX" id="yrQ-II-wy4"/>
-                                            </connections>
-                                        </barButtonItem>
-                                        <barButtonItem key="rightBarButtonItem" title="게시" id="Rwm-Zz-pW2">
-                                            <connections>
-                                                <action selector="createButton:" destination="Y6W-OH-hqX" id="DwT-qS-V7m"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="사용자 닉네임" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yh1-ND-DL0">
-                                <rect key="frame" x="20" y="123" width="93" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="스레드를 시작하세요..." textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="fR4-j5-sM5">
-                                <rect key="frame" x="20" y="218" width="353" height="200"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nud-gU-eRe">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="50"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FdX-W5-D59">
+                                        <rect key="frame" x="11" y="8" width="54" height="35"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="취소"/>
+                                        <connections>
+                                            <action selector="cancelButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="1uS-c7-YWH"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xgw-EF-dTt">
+                                        <rect key="frame" x="321" y="7" width="54" height="35"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="게시"/>
+                                        <connections>
+                                            <action selector="postingButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="dTX-Mx-yI2"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemGray2Color"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="200" id="uqY-Mh-FiC"/>
+                                    <constraint firstAttribute="height" constant="50" id="eph-YP-4jv"/>
                                 </constraints>
-                                <color key="textColor" systemColor="labelColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                            </textView>
-                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="제목을 입력해주세요..." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="i3V-6i-QCK">
-                                <rect key="frame" x="20" y="164" width="353" height="34"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
+                            </view>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IaL-yq-pvP">
+                                <rect key="frame" x="0.0" y="70" width="393" height="699"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="qZ8-ty-1qH">
+                                        <rect key="frame" x="0.0" y="0.0" width="393" height="250"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="jUZ-Bz-E00">
+                                                <rect key="frame" x="0.0" y="0.0" width="393" height="30"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="defaultProfileImage" translatesAutoresizingMaskIntoConstraints="NO" id="kWX-dW-XUR">
+                                                        <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="30" id="65U-cM-sJf"/>
+                                                        </constraints>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadious">
+                                                                <real key="value" value="15"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Uxn-Ai-1fT">
+                                                        <rect key="frame" x="45" y="0.0" width="348" height="30"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="30" id="X2t-Uh-fsw"/>
+                                                </constraints>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layoutMarginLeft">
+                                                        <real key="value" value="10"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layoutMarginRight">
+                                                        <real key="value" value="10"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="7eK-Ns-7GM">
+                                                <rect key="frame" x="0.0" y="50" width="393" height="200"/>
+                                                <subviews>
+                                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" text="스레드를 시작하세요..." translatesAutoresizingMaskIntoConstraints="NO" id="XlT-qO-UvM">
+                                                        <rect key="frame" x="0.0" y="0.0" width="393" height="159.66666666666666"/>
+                                                        <color key="textColor" systemColor="labelColor"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadious">
+                                                                <real key="value" value="10"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </textView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="XRV-ec-iEs">
+                                                        <rect key="frame" x="0.0" y="179.66666666666669" width="393" height="20.333333333333343"/>
+                                                        <subviews>
+                                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="paperclip" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="l2w-x3-Ql5" customClass="CornerRadiusChangableUIImageView" customModule="ThreadApp" customModuleProvider="target">
+                                                                <rect key="frame" x="0.0" y="-3.5527136788005009e-15" width="20" height="21"/>
+                                                                <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadious">
+                                                                        <real key="value" value="10"/>
+                                                                    </userDefinedRuntimeAttribute>
+                                                                </userDefinedRuntimeAttributes>
+                                                            </imageView>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layoutMarginLeft">
+                                                        <real key="value" value="10"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layoutMarginRight">
+                                                        <real key="value" value="10"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="qZ8-ty-1qH" firstAttribute="trailing" secondItem="UIF-df-Y3N" secondAttribute="trailing" id="2Zf-R5-Feu"/>
+                                    <constraint firstAttribute="bottom" secondItem="qZ8-ty-1qH" secondAttribute="bottom" id="E7d-Mi-9K2"/>
+                                    <constraint firstItem="qZ8-ty-1qH" firstAttribute="top" secondItem="IaL-yq-pvP" secondAttribute="top" id="nR3-hI-Lcq"/>
+                                    <constraint firstItem="qZ8-ty-1qH" firstAttribute="width" secondItem="IaL-yq-pvP" secondAttribute="width" id="rc9-o4-Xan"/>
+                                    <constraint firstItem="qZ8-ty-1qH" firstAttribute="leading" secondItem="UIF-df-Y3N" secondAttribute="leading" id="saa-QR-2PW"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="uci-RX-Jir"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="UIF-df-Y3N"/>
+                            </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="i3V-6i-QCK" firstAttribute="top" secondItem="yh1-ND-DL0" secondAttribute="bottom" constant="20" id="1Au-Dp-G9P"/>
-                            <constraint firstItem="fR4-j5-sM5" firstAttribute="top" secondItem="i3V-6i-QCK" secondAttribute="bottom" constant="20" id="8nk-jJ-73N"/>
-                            <constraint firstItem="i3V-6i-QCK" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="M0h-06-TMp"/>
-                            <constraint firstItem="MDH-wb-mUF" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="M6C-VD-hmV"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="i3V-6i-QCK" secondAttribute="trailing" constant="20" id="WYM-TO-eNR"/>
-                            <constraint firstItem="fR4-j5-sM5" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="Z1q-Sn-vxL"/>
-                            <constraint firstItem="MDH-wb-mUF" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="Zbv-JZ-Uzr"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="fR4-j5-sM5" secondAttribute="trailing" constant="20" id="odo-Sg-ZKG"/>
-                            <constraint firstItem="MDH-wb-mUF" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="pqK-MZ-LIR"/>
-                            <constraint firstItem="fR4-j5-sM5" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="rJ6-Vz-guM"/>
-                            <constraint firstItem="yh1-ND-DL0" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="20" id="x0f-SZ-B1q"/>
-                            <constraint firstItem="yh1-ND-DL0" firstAttribute="top" secondItem="MDH-wb-mUF" secondAttribute="bottom" constant="20" id="xUm-gR-uqK"/>
+                            <constraint firstItem="nud-gU-eRe" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" id="2Xw-Gu-3VL"/>
+                            <constraint firstItem="IaL-yq-pvP" firstAttribute="bottom" secondItem="vDu-zF-Fre" secondAttribute="bottom" id="7Rt-AS-Z4E"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="IaL-yq-pvP" secondAttribute="trailing" id="Anl-DJ-R6f"/>
+                            <constraint firstItem="IaL-yq-pvP" firstAttribute="top" secondItem="nud-gU-eRe" secondAttribute="bottom" constant="20" id="UcR-L4-CAq"/>
+                            <constraint firstAttribute="trailing" secondItem="nud-gU-eRe" secondAttribute="trailing" id="hK9-9T-NRM"/>
+                            <constraint firstItem="IaL-yq-pvP" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="hyx-lc-YZF"/>
+                            <constraint firstItem="nud-gU-eRe" firstAttribute="leading" secondItem="5EZ-qb-Rvc" secondAttribute="leading" id="nbe-ph-HZd"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="새 글 작성" image="pencil" catalog="system" id="K6J-KO-BCc"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="threadText" destination="fR4-j5-sM5" id="ezS-WM-N15"/>
-                        <outlet property="threadTitle" destination="i3V-6i-QCK" id="flD-YY-Tjh"/>
-                        <outlet property="userName" destination="yh1-ND-DL0" id="jZg-Df-udN"/>
+                        <outlet property="profileImageView" destination="kWX-dW-XUR" id="SLn-c8-KkJ"/>
+                        <outlet property="scrollView" destination="IaL-yq-pvP" id="PFj-ub-U2A"/>
+                        <outlet property="threadImageView" destination="l2w-x3-Ql5" id="hVP-dz-g3E"/>
+                        <outlet property="threadText" destination="XlT-qO-UvM" id="zkS-as-39O"/>
+                        <outlet property="userName" destination="Uxn-Ai-1fT" id="oRB-zm-scM"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -86,13 +162,23 @@
             <point key="canvasLocation" x="104.58015267175573" y="-2.1126760563380285"/>
         </scene>
     </scenes>
+    <designables>
+        <designable name="l2w-x3-Ql5">
+            <size key="intrinsicContentSize" width="20" height="20.333333333333329"/>
+        </designable>
+    </designables>
     <resources>
+        <image name="defaultProfileImage" width="1524" height="976"/>
+        <image name="paperclip" catalog="system" width="121" height="128"/>
         <image name="pencil" catalog="system" width="128" height="113"/>
         <systemColor name="labelColor">
             <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray2Color">
+            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/ThreadApp/resource/MainCollectionViewCell.xib
+++ b/ThreadApp/resource/MainCollectionViewCell.xib
@@ -88,14 +88,14 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="9W1-aT-ooi">
                                                 <rect key="frame" x="0.0" y="0.0" width="369" height="50"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="프로필 이름" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LLO-aB-iLP">
-                                                        <rect key="frame" x="0.0" y="14.999999999999998" width="259" height="20.333333333333329"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="프로필 이름" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LLO-aB-iLP">
+                                                        <rect key="frame" x="0.0" y="14.999999999999998" width="77.666666666666671" height="20.333333333333329"/>
                                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="시간" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S2B-WB-EJR">
-                                                        <rect key="frame" x="274" y="14.999999999999998" width="70" height="20.333333333333329"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="시간" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S2B-WB-EJR">
+                                                        <rect key="frame" x="92.666666666666657" y="14.999999999999998" width="70" height="20.333333333333329"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="70" id="CfG-g3-Ey2"/>
                                                         </constraints>
@@ -103,11 +103,8 @@
                                                         <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zxa-UL-TC6">
-                                                        <rect key="frame" x="359" y="0.0" width="10" height="50"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="10" id="kXR-tX-kxJ"/>
-                                                        </constraints>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zxa-UL-TC6">
+                                                        <rect key="frame" x="177.66666666666663" y="0.0" width="191.33333333333337" height="50"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -125,6 +122,11 @@
                                                     </label>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="bJQ-uL-TC3">
                                                         <rect key="frame" x="0.0" y="40.333333333333329" width="369" height="60.333333333333329"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadious">
+                                                                <real key="value" value="20"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="답글 3개 좋아요 76개" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tjG-6y-ZSZ">
                                                         <rect key="frame" x="0.0" y="120.66666666666664" width="369" height="20.333333333333329"/>
@@ -135,6 +137,11 @@
                                                 </subviews>
                                             </stackView>
                                         </subviews>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="layoutMarginRight">
+                                                <real key="value" value="30"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
                                     </stackView>
                                 </subviews>
                             </stackView>


### PR DESCRIPTION
# 한일 

- 이미지를 추가할 수 있게 하였습니다
- 스크롤 가능하도록 했습니다. 
- 텍스트뷰의 입력 양에 따라서 동적으로 뷰가 변할 수 있게 했습니다.
- 키보드 엔터를 눌렀을 때 키보드가 내려가도록 했습니다.  
- 스레드 앱과 비슷하게 탑 바를 변경했습니다. 

<img width="363" alt="image" src="https://github.com/cheshire0105/ThreadApp/assets/139723584/d2021894-8c0c-46be-98a9-51c6a4d97b9a">

<img width="364" alt="image" src="https://github.com/cheshire0105/ThreadApp/assets/139723584/8d1dfbc9-371c-4b3c-9c6a-251c4807dbb1">

<img width="364" alt="image" src="https://github.com/cheshire0105/ThreadApp/assets/139723584/1556fb99-b1b4-4ecb-a5b4-8fa594751465">

